### PR TITLE
adds pref-link generation method in sdk

### DIFF
--- a/examples/standalone-playground/src/pages/index.tsx
+++ b/examples/standalone-playground/src/pages/index.tsx
@@ -1,13 +1,16 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import courierSDK from "@trycourier/courier-js";
+import Link from "next/link";
+
+courierSDK.init({
+  clientKey: "<REPLACE_ME_WITH_REAL_KEY>",
+  debug: true,
+});
 
 export default function Example() {
-  useEffect(() => {
-    courierSDK.init({
-      clientKey: "<REPLACE_WITH_YOUR_CLIENT_KEY>",
-      debug: true,
-    });
-  }, []);
+  const [prefLink] = useState<string>(
+    courierSDK.generatePreferencesUrl("suhas_demo")
+  );
 
   async function handleEvent(
     event: "identity" | "subscribe" | "unsubscribe" | "track"
@@ -36,6 +39,9 @@ export default function Example() {
   return (
     <div>
       <h1>Courier-js</h1>
+      <h2>
+        <Link href={prefLink}>Manage your preferences</Link>
+      </h2>
       <button onClick={() => handleEvent("identity")}>Identify</button>
       <button onClick={() => handleEvent("subscribe")}>Subscribe</button>
       <button onClick={() => handleEvent("unsubscribe")}>Unsubscribe</button>

--- a/packages/courier-js/README.md
+++ b/packages/courier-js/README.md
@@ -1,4 +1,4 @@
-[![Courier: Your Complete Communication Stack](https://marketing-assets-public.s3.us-west-1.amazonaws.com/github_nodejs.png)](https://courier.com)
+[![Courier: Your Complete Communication Stack](https://www.courier.com/_next/image/?url=https%3A%2F%2Fimages.ctfassets.net%2Fz7iqk1q8njt4%2F1PZo9WNTdmoDoYH3yulXa0%2Fb10830f7bfb09af5e644a39ac3d20c41%2FCourierJS_header_alt2.png&w=1920&q=75)](https://courier.com)
 
 ## Requirements
 
@@ -30,5 +30,16 @@ Upon initialization, you can use the SDK. All the methods are async and return a
 */
 courier.identify("<your_user_id>", {
   email: "suhas+from+ui@courier.com",
+});
+```
+
+## Send User to Preference Center
+
+This method generates a URL that you can use to send your users to the Courier Preference Center to let them manage their notification preferences. You can use this URL in your application to send your users to the Preference Center.
+
+```ts
+const prefCenterLink = courier.generatePreferencesUrl("<your_user_id>", {
+  // optional
+  brandId: "<your_brand_id>",
 });
 ```

--- a/packages/courier-js/package.json
+++ b/packages/courier-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier-js",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/courier-js/package.json
+++ b/packages/courier-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier-js",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/courier-js/src/helpers/client.ts
+++ b/packages/courier-js/src/helpers/client.ts
@@ -31,7 +31,7 @@ async function tryCatch(
 export class Courier {
   private authorization?: string;
   private baseUrl: string;
-  public clientKey?: string;
+  private clientKey?: string;
   private debug?: boolean;
   private userId?: string;
   private userSignature?: string;

--- a/packages/courier-js/src/helpers/client.ts
+++ b/packages/courier-js/src/helpers/client.ts
@@ -31,7 +31,7 @@ async function tryCatch(
 export class Courier {
   private authorization?: string;
   private baseUrl: string;
-  public clientKey: string;
+  private clientKey: string;
   private debug?: boolean;
   private userId?: string;
   private userSignature?: string;

--- a/packages/courier-js/src/helpers/client.ts
+++ b/packages/courier-js/src/helpers/client.ts
@@ -1,4 +1,5 @@
 import { version } from "../../package.json";
+import { encode, decode } from "./decode";
 
 export type CourierOptions = {
   authorization?: string;
@@ -7,6 +8,10 @@ export type CourierOptions = {
   debug?: boolean;
   userId?: string;
   userSignature?: string;
+};
+
+export type PreferenceLinkOptions = {
+  brandId?: string;
 };
 
 async function tryCatch(
@@ -26,7 +31,7 @@ async function tryCatch(
 export class Courier {
   private authorization?: string;
   private baseUrl: string;
-  private clientKey?: string;
+  public clientKey?: string;
   private debug?: boolean;
   private userId?: string;
   private userSignature?: string;
@@ -95,5 +100,19 @@ export class Courier {
       });
     };
     await tryCatch(deleteFn, this.debug);
+  }
+
+  generatePreferencesUrl(
+    userId: string,
+    options?: PreferenceLinkOptions
+  ): string {
+    if (!userId || !this.clientKey) {
+      throw new Error("userId is required");
+    }
+    const id = decode(this.clientKey);
+
+    return `https://view.notificationcenter.app/p/${encode(
+      `${id}#${options?.brandId ?? ""}#${userId}#${false}`
+    )}`;
   }
 }

--- a/packages/courier-js/src/helpers/client.ts
+++ b/packages/courier-js/src/helpers/client.ts
@@ -31,7 +31,7 @@ async function tryCatch(
 export class Courier {
   private authorization?: string;
   private baseUrl: string;
-  private clientKey?: string;
+  public clientKey: string;
   private debug?: boolean;
   private userId?: string;
   private userSignature?: string;
@@ -44,7 +44,7 @@ export class Courier {
     userId,
     userSignature,
   }: CourierOptions) {
-    if (!clientKey || authorization) {
+    if (!clientKey) {
       throw new Error("Courier client key is required");
     }
     this.authorization = authorization;
@@ -106,8 +106,8 @@ export class Courier {
     userId: string,
     options?: PreferenceLinkOptions
   ): string {
-    if (!userId || !this.clientKey) {
-      throw new Error("userId and clientKey are required");
+    if (!userId) {
+      throw new Error("User ID is required to generate preferences URL");
     }
     const id = decode(this.clientKey);
 

--- a/packages/courier-js/src/helpers/client.ts
+++ b/packages/courier-js/src/helpers/client.ts
@@ -107,7 +107,7 @@ export class Courier {
     options?: PreferenceLinkOptions
   ): string {
     if (!userId || !this.clientKey) {
-      throw new Error("userId is required");
+      throw new Error("userId and clientKey are required");
     }
     const id = decode(this.clientKey);
 

--- a/packages/courier-js/src/helpers/decode.ts
+++ b/packages/courier-js/src/helpers/decode.ts
@@ -1,0 +1,20 @@
+export function decode(clientKey: string): string {
+  const binaryString = atob(clientKey);
+  const bytes = new Uint8Array(binaryString.length);
+
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+
+  return String.fromCharCode(...bytes);
+}
+
+export function encode(key: string): string {
+  const bytes = new Uint8Array(key.length);
+
+  for (let i = 0; i < key.length; i++) {
+    bytes[i] = key.charCodeAt(i);
+  }
+
+  return btoa(String.fromCharCode(...bytes));
+}

--- a/packages/courier-js/src/index.ts
+++ b/packages/courier-js/src/index.ts
@@ -19,11 +19,7 @@ const client = {
     if (!userId) {
       throw new Error("userId is required");
     }
-    await this.instance.post(`identify/${userId}`, {
-      profile: {
-        ...payload,
-      },
-    });
+    await this.instance.post(`identify/${userId}`, payload);
   },
   // apply common decorator to check if __instance is initialized
   async subscribe(userId: string, listId: string) {

--- a/packages/courier-js/src/index.ts
+++ b/packages/courier-js/src/index.ts
@@ -1,4 +1,8 @@
-import { Courier, CourierOptions } from "./helpers/client";
+import {
+  Courier,
+  CourierOptions,
+  PreferenceLinkOptions,
+} from "./helpers/client";
 
 const client = {
   __instance: null as Courier | null,
@@ -15,7 +19,11 @@ const client = {
     if (!userId) {
       throw new Error("userId is required");
     }
-    await this.instance.post(`identify/${userId}`, payload);
+    await this.instance.post(`identify/${userId}`, {
+      profile: {
+        ...payload,
+      },
+    });
   },
   // apply common decorator to check if __instance is initialized
   async subscribe(userId: string, listId: string) {
@@ -29,6 +37,13 @@ const client = {
       throw new Error("userId is required");
     }
     this.instance.delete(`lists/${listId}/unsubscribe/${userId}`);
+  },
+
+  generatePreferencesUrl(
+    userId: string,
+    options?: PreferenceLinkOptions
+  ): string {
+    return this.instance.generatePreferencesUrl(userId, options);
   },
 };
 


### PR DESCRIPTION

This PR adds a method that allows generating preference center URL that you can use to send your users to the Courier's hosted Preference Center to let them manage their notification preferences. You can use this URL in your application to send your users to the Preference Center.

```ts
const prefCenterLink = courier.generatePreferencesUrl("<your_user_id>", {
  // optional
  brandId: "<your_brand_id>",
});
```